### PR TITLE
Docs: Expand sample output of `sampleToJson`

### DIFF
--- a/System/Metrics/Json.hs
+++ b/System/Metrics/Json.hs
@@ -176,12 +176,15 @@ typeMismatch expected actual =
         A.Bool _   -> "Boolean"
         A.Null     -> "Null"
 
--- | Encodes a single metric as a JSON object. Example:
+-- | Encodes a single metric as a JSON object. For example:
 --
--- > {
--- >   "type": "c",
--- >   "val": 89460
--- > }
+-- >>> valueToJson (Counter 89460)
+-- Object (fromList [("type",String "c"),("val",Number 89460.0)])
+-- -- { "type": "c", "val": 89460 }
+--
+-- (To prevent any possible confusion, the input is of type
+-- 'System.Metrics.Value' from "System.Metrics", and the output is of
+-- type 'Data.Aeson.Value' from "Data.Aeson".)
 --
 valueToJson :: Metrics.Value -> A.Value
 valueToJson (Metrics.Counter n)      = scalarToJson n CounterType

--- a/System/Metrics/Json.hs
+++ b/System/Metrics/Json.hs
@@ -37,43 +37,77 @@ import qualified System.Metrics.Distribution as Distribution
 -- | Encode metrics as nested JSON objects. Each "." in the metric name
 -- introduces a new level of nesting.
 --
--- For example, the metric set
+-- For example, a set of metrics consisting of
 --
--- > ("foo.bar", {}, "label")
--- > ("foo.baz", {"tag","a"}, 10)
--- > ("foo.baz", {"tag","b"}, 11)
+-- (1) a metric named @foo.counter@, with tags @{key1:"val1"}@, of type
+-- @Counter@, and with value @10@;
+-- (2) a metric named @foo.counter@, with tags @{key1:"val2"}@, of type
+-- @Counter@, and with value @11@;
+-- (3) a metric named @foo.distribution@, with no tags, of type
+-- @Distribution@, and with value
+-- @Distribution{count=1, max=1, mean=1, min=1, sum=1, variance=0}@;
+-- (4) a metric named @gauge@, with no tags, of type @Gauge@, and with
+-- value @100@; and
+-- (5) a metric named @label@, with no tags, of type @Label@, and with
+-- value @"bar"@
 --
 -- is encoded as
 --
 -- > {
 -- >   "foo": {
--- >     "bar": [
--- >       { "tags": {},
--- >         "value": {
--- >           "type": "l",
--- >           "val": "label"
--- >         }
--- >       }
--- >     ],
--- >     "baz": [
--- >       { "tags": {
--- >           "tag": "a"
--- >         },
--- >         "value": {
--- >           "type": "c",
--- >           "val": 10
--- >         }
--- >       },
--- >       { "tags": {
--- >           "tag": "b"
+-- >     "counter": [
+-- >       {
+-- >         "tags": {
+-- >           "key1": "val2"
 -- >         },
 -- >         "value": {
 -- >           "type": "c",
 -- >           "val": 11
 -- >         }
+-- >       },
+-- >       {
+-- >         "tags": {
+-- >           "key1": "val1"
+-- >         },
+-- >         "value": {
+-- >           "type": "c",
+-- >           "val": 10
+-- >         }
+-- >       }
+-- >     ],
+-- >     "distribution": [
+-- >       {
+-- >         "tags": {},
+-- >         "value": {
+-- >           "count": 1,
+-- >           "max": 1,
+-- >           "mean": 1,
+-- >           "min": 1,
+-- >           "sum": 1,
+-- >           "type": "d",
+-- >           "variance": 0
+-- >         }
 -- >       }
 -- >     ]
--- >   }
+-- >   },
+-- >   "gauge": [
+-- >     {
+-- >       "tags": {},
+-- >       "value": {
+-- >         "type": "g",
+-- >         "val": 100
+-- >       }
+-- >     }
+-- >   ],
+-- >   "label": [
+-- >     {
+-- >       "tags": {},
+-- >       "value": {
+-- >         "type": "l",
+-- >         "val": "bar"
+-- >       }
+-- >     }
+-- >   ]
 -- > }
 --
 sampleToJson :: Metrics.Sample -> A.Value

--- a/ekg-json.cabal
+++ b/ekg-json.cabal
@@ -38,6 +38,22 @@ library
     -Wredundant-constraints
   default-language: Haskell2010
 
+test-suite tests
+  type:
+    exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  main-is:
+    Main.hs
+  build-depends:
+    aeson,
+    base,
+    ekg-core,
+    ekg-json,
+    hspec,
+    text,
+    unordered-containers
+
 source-repository head
   type:     git
   location: https://github.com/tibbe/ekg-json.git

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Data.Aeson (encode)
+import qualified Data.HashMap.Strict as M
+import Data.Kind (Type)
+import qualified Data.Text as T
+import GHC.Exts (fromString)
+import GHC.TypeLits (Symbol)
+import System.Metrics
+import qualified System.Metrics.Counter as Counter
+import qualified System.Metrics.Distribution as Distribution
+import qualified System.Metrics.Gauge as Gauge
+import qualified System.Metrics.Label as Label
+import Test.Hspec
+  ( Spec,
+    describe,
+    hspec,
+    it,
+    shouldBe,
+  )
+
+import System.Metrics.Json
+
+main :: IO ()
+main = hspec exampleSpec
+
+-- | Test whether the output of 'sampleToJson' is consistent with its
+-- Haddocks.
+--
+-- Note: The example output in the Haddocks has been formatted by
+-- passing it through the `jq` program.
+exampleSpec :: Spec
+exampleSpec =
+  describe "The output of `sampleToJson`" $
+    it "is consistent with its haddocks" $ do
+
+  store <- newStore @ExampleMetrics
+
+  counter1 <-
+    createCounter ExampleCounter (M.singleton "key1" "val1") store
+  Counter.add counter1 10
+
+  counter2 <-
+    createCounter ExampleCounter (M.singleton "key1" "val2") store
+  Counter.add counter2 11
+
+  distribution <- createDistribution ExampleDistribution () store
+  Distribution.add distribution 1
+
+  gauge <- createGauge ExampleGauge () store
+  Gauge.set gauge 100
+
+  label <- createLabel ExampleLabel () store
+  Label.set label "bar"
+
+  jsonSample <- encode . sampleToJson <$> sampleAll store
+
+  shouldBe jsonSample "{\"foo\":{\"counter\":[{\"tags\":{\"key1\":\"val2\"},\"value\":{\"type\":\"c\",\"val\":11}},{\"tags\":{\"key1\":\"val1\"},\"value\":{\"type\":\"c\",\"val\":10}}],\"distribution\":[{\"tags\":{},\"value\":{\"count\":1,\"max\":1,\"mean\":1,\"min\":1,\"sum\":1,\"type\":\"d\",\"variance\":0}}]},\"gauge\":[{\"tags\":{},\"value\":{\"type\":\"g\",\"val\":100}}],\"label\":[{\"tags\":{},\"value\":{\"type\":\"l\",\"val\":\"bar\"}}]}"
+
+data ExampleMetrics :: Symbol -> MetricType -> Type -> Type where
+  ExampleCounter
+    :: ExampleMetrics "foo.counter" 'CounterType (M.HashMap T.Text T.Text)
+  ExampleDistribution
+    :: ExampleMetrics "foo.distribution" 'DistributionType ()
+  ExampleGauge
+    :: ExampleMetrics "gauge" 'GaugeType ()
+  ExampleLabel
+    :: ExampleMetrics "label" 'LabelType ()


### PR DESCRIPTION
This PR adds documentation to more fully describe the JSON metrics format emitted by `sampleToJson`.

Specifically, it extends the sample output in the Haddocks of `sampleToJson` to include a metric of each metric type.